### PR TITLE
StatsD namespace and sample rate are configurable

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -174,23 +174,13 @@ func eventWorker() {
 				elapsed := time.Since(start)
 				if err != nil {
 					logger.Error("config update failed")
-					if config.Statsd != "" {
-						go func() {
-							hostname, _ := os.Hostname()
-							statsd.Counter(1.0, "nixy."+hostname+".reload.failed", 1)
-						}()
-					}
+					go statsCount("reload.failed", 1)
 				} else {
 					logger.WithFields(logrus.Fields{
 						"took": elapsed,
 					}).Info("config updated")
-					if config.Statsd != "" {
-						go func(elapsed time.Duration) {
-							hostname, _ := os.Hostname()
-							statsd.Counter(1.0, "nixy."+hostname+".reload.success", 1)
-							statsd.Timing(1.0, "nixy."+hostname+".reload.time", elapsed)
-						}(elapsed)
-					}
+					go statsCount("reload.success", 1)
+					go statsTiming("reload.time", elapsed)
 				}
 			}
 		}

--- a/nixy.go
+++ b/nixy.go
@@ -27,15 +27,21 @@ type App struct {
 type Config struct {
 	sync.RWMutex
 	Xproxy         string
-	Port           string   `json:"-"`
-	Marathon       []string `json:"-"`
-	User           string   `json:"-"`
-	Pass           string   `json:"-"`
-	Nginx_config   string   `json:"-"`
-	Nginx_template string   `json:"-"`
-	Nginx_cmd      string   `json:"-"`
-	Statsd         string
+	Port           string       `json:"-"`
+	Marathon       []string     `json:"-"`
+	User           string       `json:"-"`
+	Pass           string       `json:"-"`
+	Nginx_config   string       `json:"-"`
+	Nginx_template string       `json:"-"`
+	Nginx_cmd      string       `json:"-"`
+	Statsd         StatsdConfig `json:"-"`
 	Apps           map[string]App
+}
+
+type StatsdConfig struct {
+	Addr       string
+	Namespace  string
+	SampleRate int `toml:"sample_rate"`
 }
 
 // Global variables
@@ -128,9 +134,9 @@ func main() {
 			"error": err.Error(),
 		}).Fatal("problem parsing config")
 	}
-	if config.Statsd != "" {
-		statsd, _ = g2s.Dial("udp", config.Statsd)
-	}
+
+	statsd, _ = setupStatsd()
+
 	mux := mux.NewRouter()
 	mux.HandleFunc("/", nixy_version)
 	mux.HandleFunc("/v1/reload", nixy_reload)

--- a/nixy.toml
+++ b/nixy.toml
@@ -11,4 +11,7 @@ nginx_config = "/etc/nginx/nginx.conf"
 nginx_template = "/etc/nginx/nginx.tmpl"
 nginx_cmd = "nginx" # optinally openresty
 # statsd settings
-statsd = "localhost:8125" # optional for statistics
+[statsd]
+addr = "localhost:8125" # optional for statistics
+#namespace = "nixy.my_mesos_cluster"
+#sample_rate = 100

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/peterbourgon/g2s"
+)
+
+func setupStatsd() (g2s.Statter, error) {
+	if config.Statsd.Addr == "" {
+		return g2s.Noop(), nil
+	}
+
+	if config.Statsd.Namespace == "" {
+		hostname, _ := os.Hostname()
+		config.Statsd.Namespace = "nixy." + hostname
+	}
+
+	if config.Statsd.SampleRate < 1 || config.Statsd.SampleRate > 100 {
+		config.Statsd.SampleRate = 100
+	}
+
+	return g2s.Dial("udp", config.Statsd.Addr)
+}
+
+func statsCount(metric string, n int) {
+	ns := config.Statsd.Namespace
+	statsd.Counter(1.0, ns+"."+metric, n)
+}
+
+func statsTiming(metric string, elapsed time.Duration) {
+	ns := config.Statsd.Namespace
+	statsd.Timing(1.0, ns+"."+metric, elapsed)
+}


### PR DESCRIPTION
This pull requests enables operators to specify the namespace and sample-rate for Nginx StatsD metrics.

While easy to update, the toml configuration changes in a breaking way. What was:

```
statsd = ...
```

changes to:

```
[statsd]
addr = ...
```
