### PR TITLE
add timeout for event stream listener to re-attach to healthy endpoint

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -48,7 +48,7 @@ type MarathonApps struct {
 func eventStream() {
 	go func() {
 		client := &http.Client{
-			Timeout:   0 * time.Second,
+			Timeout:   10 * time.Second,
 			Transport: tr,
 		}
 		ticker := time.NewTicker(1 * time.Second)


### PR DESCRIPTION
When endpoints go down for some time and come up again the health check recognized this. Manual reload do work afterwards but the event stream listener will not reconnect to the endpoint since it can get stuck due on the "old" http connection to a missing timeout. 

I added a 10 sec timeout (similar to health check) so it would try to reconnect the http client if that connection times out.
