### PR TITLE
Add timestamps of last updates to config data

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -325,10 +325,7 @@ func syncApps(jsontasks *MarathonTasks, jsonapps *MarathonApps) {
 				config.Apps[app.Id] = newapp
 			}
 		}
-
 	}
-	config.LastUpdate = time.Now()
-
 }
 
 func writeConf() error {
@@ -397,6 +394,7 @@ func reload() error {
 		return err
 	}
 	syncApps(&jsontasks, &jsonapps)
+	config.LastUpdates.LastSync = time.Now()
 	err = writeConf()
 	if err != nil {
 		logger.WithFields(logrus.Fields{
@@ -404,6 +402,7 @@ func reload() error {
 		}).Error("unable to generate nginx config")
 		return err
 	}
+	config.LastUpdates.LastConfigWrite = time.Now()
 	err = reloadNginx()
 	if err != nil {
 		logger.WithFields(logrus.Fields{
@@ -411,5 +410,6 @@ func reload() error {
 		}).Error("unable to reload nginx")
 		return err
 	}
+	config.LastUpdates.LastNginxReload = time.Now()
 	return nil
 }

--- a/marathon.go
+++ b/marathon.go
@@ -327,6 +327,7 @@ func syncApps(jsontasks *MarathonTasks, jsonapps *MarathonApps) {
 		}
 
 	}
+	config.LastUpdate = time.Now()
 
 }
 

--- a/nixy.go
+++ b/nixy.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Sirupsen/logrus"
@@ -26,6 +27,7 @@ type App struct {
 
 type Config struct {
 	sync.RWMutex
+	LastUpdate     time.Time
 	Xproxy         string
 	Port           string   `json:"-"`
 	Marathon       []string `json:"-"`

--- a/nixy.go
+++ b/nixy.go
@@ -27,7 +27,6 @@ type App struct {
 
 type Config struct {
 	sync.RWMutex
-	LastUpdate     time.Time
 	Xproxy         string
 	Port           string   `json:"-"`
 	Marathon       []string `json:"-"`
@@ -37,7 +36,14 @@ type Config struct {
 	Nginx_template string   `json:"-"`
 	Nginx_cmd      string   `json:"-"`
 	Statsd         StatsdConfig
+	LastUpdates    Updates
 	Apps           map[string]App
+}
+
+type Updates struct {
+	LastSync        time.Time
+	LastConfigWrite time.Time
+	LastNginxReload time.Time
 }
 
 type StatsdConfig struct {


### PR DESCRIPTION
Adding some debug information about last sync, last config generation and last nginx reload to the config data accessible via /v1/config
