### PR TITLE
use timeout on event stream reader to reconnect to healthy backend

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -66,7 +66,7 @@ func eventStream() {
 				req.SetBasicAuth(config.User, config.Pass)
 			}
 			cancel := make(chan struct{})
-			// initial request cancellation timer of 20s
+			// initial request cancellation timer of 15s
 			timer := time.AfterFunc(15 * time.Second, func() {
 				close(cancel)
 				logger.Warn("event stream request was cancelled")

--- a/marathon.go
+++ b/marathon.go
@@ -65,16 +65,28 @@ func eventStream() {
 			if config.User != "" {
 				req.SetBasicAuth(config.User, config.Pass)
 			}
+			cancel := make(chan struct{})
+			// initial request cancellation timer of 20s
+			timer := time.AfterFunc(15 * time.Second, func() {
+				close(cancel)
+				logger.Warn("event stream request was cancelled")
+			})
+			req.Cancel = cancel
 			resp, err := client.Do(req)
 			if err != nil {
 				logger.WithFields(logrus.Fields{
 					"error":    err.Error(),
 					"endpoint": endpoint,
 				}).Error("unable to access Marathon event stream")
+				// expire request cancellation timer immediately
+				timer.Reset(100 * time.Millisecond)
 				continue
 			}
 			reader := bufio.NewReader(resp.Body)
 			for {
+				// reset request cancellation timer to 15s (should be >10s to avoid unnecessary reconnects
+				// since ~10s seems to be the rate for dummy/keepalive events on the marathon event stream
+				timer.Reset(15 * time.Second)
 				line, err := reader.ReadString('\n')
 				if err != nil {
 					if err != io.EOF {


### PR DESCRIPTION
I think I found a quite good solution. Took it from the link you were mentioning in the other PR. There this approach was recommended for streaming clients. It will now reset a request cancellation timer on every event read from the stream. If it does not get a new event within the timeout the timer will cancel the request which will log a warning and the for-loop will then trigger a new request. I set the timeout to 15s since marathon seems to send a dummy/keep-alive request every 10s by default. This way it does cancel to early.
