### PR TITLE
catch closing of closed cancellation channel

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -77,8 +77,11 @@ func eventStream() {
 			}
 			cancel := make(chan struct{})
 			// initial request cancellation timer of 15s
-			timer := time.AfterFunc(15*time.Second, func() {
-				close(cancel)
+			timer := time.AfterFunc(15 * time.Second, func() {
+				defer func() {
+					recover()
+				}()
+				defer close(cancel)
 				logger.Warn("event stream request was cancelled")
 			})
 			req.Cancel = cancel


### PR DESCRIPTION
In rare cases I got am exception when at the timeout I try to close the request cancellation channel but it was already closed. The problem is you cannot really check if a channel was already closed from this side. With using recover() it will catch this exception and just ignore if the channel was already closed.
