### PR TITLE
Make writeConf safer

### DIFF
--- a/nixy.go
+++ b/nixy.go
@@ -118,7 +118,7 @@ func nixy_health(w http.ResponseWriter, r *http.Request) {
 		health.Template.Message = "OK"
 		health.Template.Healthy = true
 	}
-	err = checkConf()
+	err = checkConf(config.Nginx_config)
 	if err != nil {
 		health.Config.Message = err.Error()
 		health.Config.Healthy = false


### PR DESCRIPTION
Currently if for some reason bad Nginx configuration will be generated
the file which is used by Nginx will be replaced anyway. There is a
health check that tells if current configuration is valid.

Patch replaces main file only when it's valid (nginx -t). This way if
Nginx needs to be restared (not reloaded) it will always have valid
configuration to read from. This is our scenario as we're aiming to run
Nixy and Nginx in separate containers.
