### PR TITLE
Adjust timestamps to new config generation process

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -391,6 +391,7 @@ func writeConf() error {
 	if err != nil {
 		return err
 	}
+	config.LastUpdates.LastConfigRendered = time.Now()
 
 	err = checkConf(tmpFile.Name())
 	if err != nil {
@@ -462,7 +463,7 @@ func reload() error {
 		}).Error("unable to generate nginx config")
 		return err
 	}
-	config.LastUpdates.LastConfigWrite = time.Now()
+	config.LastUpdates.LastConfigValid = time.Now()
 	err = reloadNginx()
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/nixy.go
+++ b/nixy.go
@@ -56,9 +56,10 @@ type Config struct {
 }
 
 type Updates struct {
-	LastSync        time.Time
-	LastConfigWrite time.Time
-	LastNginxReload time.Time
+	LastSync           	time.Time
+	LastConfigRendered	time.Time
+	LastConfigValid		time.Time
+	LastNginxReload    	time.Time
 }
 
 type StatsdConfig struct {


### PR DESCRIPTION
I adjusted the updates timestamp in the config a bit to fir to the 2-staged config generation introduced with #14. So now you can differ between sync, rendering, config-test and actual reload.
