### PR TITLE
Send status code 500 if something is unhealthy

### DIFF
--- a/nixy.go
+++ b/nixy.go
@@ -131,6 +131,7 @@ func nixy_health(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		health.Template.Message = err.Error()
 		health.Template.Healthy = false
+		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		health.Template.Message = "OK"
 		health.Template.Healthy = true
@@ -139,9 +140,16 @@ func nixy_health(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		health.Config.Message = err.Error()
 		health.Config.Healthy = false
+		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		health.Config.Message = "OK"
 		health.Config.Healthy = true
+	}
+	for _, endpoint := range health.Endpoints {
+		if (!endpoint.Healthy) {
+			w.WriteHeader(http.StatusInternalServerError)
+			break;
+		}
 	}
 	w.Header().Add("Content-Type", "application/json; charset=utf-8")
 	b, _ := json.MarshalIndent(health, "", "  ")

--- a/nixy.go
+++ b/nixy.go
@@ -145,10 +145,14 @@ func nixy_health(w http.ResponseWriter, r *http.Request) {
 		health.Config.Message = "OK"
 		health.Config.Healthy = true
 	}
+	all_backends_down := true;
 	for _, endpoint := range health.Endpoints {
 		if (endpoint.Healthy) {
+			all_backends_down = false;
 			break;
 		}
+	}
+	if all_backends_down {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.Header().Add("Content-Type", "application/json; charset=utf-8")

--- a/nixy.go
+++ b/nixy.go
@@ -146,10 +146,10 @@ func nixy_health(w http.ResponseWriter, r *http.Request) {
 		health.Config.Healthy = true
 	}
 	for _, endpoint := range health.Endpoints {
-		if (!endpoint.Healthy) {
-			w.WriteHeader(http.StatusInternalServerError)
+		if (endpoint.Healthy) {
 			break;
 		}
+		w.WriteHeader(http.StatusInternalServerError)
 	}
 	w.Header().Add("Content-Type", "application/json; charset=utf-8")
 	b, _ := json.MarshalIndent(health, "", "  ")


### PR DESCRIPTION
Simple http health check usually consider response status codes. 200 is interpreted as healthy. So we should send a non-200 status in case any of nixy's health check report unhealthy. With this PR it will set the response status code of /v1/health to 500 in such a case.
