### PR TITLE
Avoid concurrent read/write of config map in templating

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -338,6 +338,8 @@ func syncApps(jsonapps *MarathonApps) bool {
 }
 
 func writeConf() error {
+	config.RLock()
+	defer config.RUnlock()
 	template, err := template.New(filepath.Base(config.Nginx_template)).ParseFiles(config.Nginx_template)
 	if err != nil {
 		return err
@@ -364,6 +366,8 @@ func writeConf() error {
 }
 
 func checkTmpl() error {
+	config.RLock()
+	defer config.RUnlock()
 	t, err := template.New(filepath.Base(config.Nginx_template)).ParseFiles(config.Nginx_template)
 	if err != nil {
 		return err


### PR DESCRIPTION
When the application config update and the health check run in parallel in rare cases there is a concurrent read-write access issue (```fatal error: concurrent map read and map write```) on the config.Apps used by the golang templating engine.

This PR adds a read-locks on the methods accessing this map (via template engine) to avoid this.