### PR TITLE
Add optional delimiters for template parsing

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -345,8 +345,6 @@ func writeConf() error {
 		Delims(config.Left_delimiter, config.Right_delimiter).
 		ParseFiles(config.Nginx_template)
 
-	fmt.Println(template)
-
 	if err != nil {
 		return err
 	}

--- a/marathon.go
+++ b/marathon.go
@@ -340,7 +340,13 @@ func syncApps(jsonapps *MarathonApps) bool {
 func writeConf() error {
 	config.RLock()
 	defer config.RUnlock()
-	template, err := template.New(filepath.Base(config.Nginx_template)).ParseFiles(config.Nginx_template)
+
+	template, err := template.New(filepath.Base(config.Nginx_template)).
+		Delims(config.Left_delimiter, config.Right_delimiter).
+		ParseFiles(config.Nginx_template)
+
+	fmt.Println(template)
+
 	if err != nil {
 		return err
 	}
@@ -368,7 +374,10 @@ func writeConf() error {
 func checkTmpl() error {
 	config.RLock()
 	defer config.RUnlock()
-	t, err := template.New(filepath.Base(config.Nginx_template)).ParseFiles(config.Nginx_template)
+	t, err := template.New(filepath.Base(config.Nginx_template)).
+		Delims(config.Left_delimiter, config.Right_delimiter).
+		ParseFiles(config.Nginx_template)
+
 	if err != nil {
 		return err
 	}

--- a/nixy.go
+++ b/nixy.go
@@ -42,17 +42,19 @@ type App struct {
 
 type Config struct {
 	sync.RWMutex
-	Xproxy         string
-	Port           string   `json:"-"`
-	Marathon       []string `json:"-"`
-	User           string   `json:"-"`
-	Pass           string   `json:"-"`
-	Nginx_config   string   `json:"-"`
-	Nginx_template string   `json:"-"`
-	Nginx_cmd      string   `json:"-"`
-	Statsd         StatsdConfig
-	LastUpdates    Updates
-	Apps           map[string]App
+	Xproxy         	string
+	Port           	string   `json:"-"`
+	Marathon       	[]string `json:"-"`
+	User           	string   `json:"-"`
+	Pass           	string   `json:"-"`
+	Nginx_config   	string   `json:"-"`
+	Nginx_template 	string   `json:"-"`
+	Left_delimiter 	string   `json:"{{"`
+	Right_delimiter string   `json:"{{"`
+	Nginx_cmd      	string   `json:"-"`
+	Statsd         	StatsdConfig
+	LastUpdates    	Updates
+	Apps           	map[string]App
 }
 
 type Updates struct {

--- a/nixy.go
+++ b/nixy.go
@@ -50,7 +50,7 @@ type Config struct {
 	Nginx_config   	string   `json:"-"`
 	Nginx_template 	string   `json:"-"`
 	Left_delimiter 	string   `json:"{{"`
-	Right_delimiter string   `json:"{{"`
+	Right_delimiter string   `json:"}}"`
 	Nginx_cmd      	string   `json:"-"`
 	Statsd         	StatsdConfig
 	LastUpdates    	Updates

--- a/nixy.toml
+++ b/nixy.toml
@@ -10,6 +10,8 @@ pass = ""
 nginx_config = "/etc/nginx/nginx.conf"
 nginx_template = "/etc/nginx/nginx.tmpl"
 nginx_cmd = "nginx" # optionally "openresty" or "docker exec nginx nginx"
+# left_delimiter = '<<'
+# right_delimiter = '>>'
 # Statsd settings
 [statsd]
 addr = "localhost:8125" # optional for statistics


### PR DESCRIPTION
Allow to configure custom template delimiters like in `consul-template`.