### PR TITLE
Add Realm concept to Nixy.

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -241,6 +241,9 @@ func syncApps(jsonapps *MarathonApps) bool {
 	apps := make(map[string]App)
 	for _, app := range jsonapps.Apps {
 		var newapp = App{}
+		if config.Realm != "" && app.Labels["NIXY_REALM"] != config.Realm {
+			continue
+		}
 		for _, task := range app.Tasks {
 			// lets skip tasks that does not expose any ports.
 			if len(task.Ports) == 0 {

--- a/nixy.go
+++ b/nixy.go
@@ -43,6 +43,7 @@ type App struct {
 type Config struct {
 	sync.RWMutex
 	Xproxy             string
+	Realm              string
 	Port               string   `json:"-"`
 	Marathon           []string `json:"-"`
 	User               string   `json:"-"`

--- a/nixy.toml
+++ b/nixy.toml
@@ -6,6 +6,9 @@ xproxy = ""
 marathon = ["http://example01:8080", "http://example02:8080"] # add all HA cluster nodes in priority order.
 user = "" # leave empty if no auth is required.
 pass = ""
+# Nixy realm, set this if you want to be able to filter your apps (e.g. when you have different loadbalancers which should expose different apps)
+# You will also need to set "NIXY_REALM" label at your app to be included in generated conf
+realm = ""
 # Nginx
 nginx_config = "/etc/nginx/nginx.conf"
 nginx_template = "/etc/nginx/nginx.tmpl"


### PR DESCRIPTION
This commit allows users to use multiple nixy managed loadbalancers
on Marathon cluster. Each one of them will only contain part of the
services defined on the cluster, based on "NIXY_REALM" app label and
"realm" setting from nixy.toml file.