### PR TITLE
Support for Marathon's `portMapping` config

### DIFF
--- a/marathon.go
+++ b/marathon.go
@@ -32,6 +32,15 @@ type MarathonApps struct {
 			Protocol string            `json:"protocol"`
 			Labels   map[string]string `json:"labels"`
 		} `json:"portDefinitions"`
+		Container struct {
+			PortMappings []struct {
+				ContainerPort   int64             `json:"containerPort"`
+				HostPort     	int64             `json:"hostPort"`
+				Labels  		map[string]string `json:"labels"`
+				Protocol 		string            `json:"protocol"`
+				ServicePort     int64             `json:"servicePort"`
+			} `json:"portMappings"`
+		} `json:"container"`
 		Tasks []struct {
 			AppID              string `json:"appId"`
 			HealthCheckResults []struct {
@@ -366,6 +375,18 @@ func syncApps(jsonapps *MarathonApps) bool {
 				}
 				newapp.PortDefinitions = append(newapp.PortDefinitions, pd)
 			}
+
+			for _, pms := range app.Container.PortMappings {
+				pm := PortMappings{
+					ContainerPort:	pms.ContainerPort,
+					HostPort:		pms.HostPort,
+					Labels: 		pms.Labels,
+					Protocol:		pms.Protocol,
+					ServicePort: 	pms.ServicePort,
+				}
+				newapp.Container.PortMappings = append(newapp.Container.PortMappings, pm)
+			}
+
 			apps[app.ID] = newapp
 		}
 	}

--- a/nixy.go
+++ b/nixy.go
@@ -38,6 +38,20 @@ type PortDefinitions struct {
 	Labels   map[string]string
 }
 
+// PortMappings struct
+type PortMappings struct {
+	ContainerPort   int64
+	HostPort     	int64
+	Labels  		map[string]string
+	Protocol 		string
+	ServicePort     int64
+}
+
+// Container struct
+type Container struct {
+	PortMappings	[]PortMappings
+}
+
 // HealthCheck struct
 type HealthCheck struct {
 	Path string
@@ -51,6 +65,7 @@ type App struct {
 	Hosts           []string
 	PortDefinitions []PortDefinitions
 	HealthChecks    []HealthCheck
+	Container		Container
 }
 
 // Config struct used by the template engine


### PR DESCRIPTION
Marathon's `portDefinition` config is [only used when using host-mode networking](https://mesosphere.github.io/marathon/docs/networking.html#port-definition). Since Marathon 1.5, it will no longer include port-definition configuration in its API output if it is not in use, which means that it is no longer possible for Nixy to read port-level labels from the Marathon API.

This PR adds access to Marathons `app.container.portMappings` property (which is now one level higher in the json structure than it [used to be](https://mesosphere.github.io/marathon/docs/upgrade/network-api-migration.html)) to Nixy's templates, allowing us to access this configuration.

Note that is my first attempt at Go code ever, so please let me know if I made any mistakes and I'll happily fix them.